### PR TITLE
Create apps from Apps.json for testing

### DIFF
--- a/Apps/daisyui/index.html
+++ b/Apps/daisyui/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="aqua" class="bg-base-200">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>daisyui components test</title>
+
+	<!-- Tailwind v4 (browser build) then DaisyUI -->
+	<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4" defer></script>
+	<link href="https://cdn.jsdelivr.net/npm/daisyui@5" rel="stylesheet" type="text/css" />
+	<link href="https://cdn.jsdelivr.net/npm/daisyui@5/themes.css" rel="stylesheet" type="text/css" />
+</head>
+<body class="bg-base-200 min-h-screen">
+	<div class="container mx-auto p-6">
+		<div class="breadcrumbs text-sm mb-6">
+			<ul>
+				<li><a href="/">Home</a></li>
+				<li>daisyui components test</li>
+			</ul>
+		</div>
+
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+			<!-- Card -->
+			<div class="card bg-base-300 shadow-xl">
+				<div class="card-body">
+					<h2 class="card-title">Card</h2>
+					<p>Minimal daisyUI components with Tailwind v4 (no build).</p>
+					<div class="card-actions justify-end">
+						<button class="btn btn-primary">Primary</button>
+						<button class="btn btn-secondary">Secondary</button>
+						<button class="btn btn-accent">Accent</button>
+					</div>
+				</div>
+			</div>
+
+			<!-- Tabs -->
+			<div class="card bg-base-300 shadow-xl">
+				<div class="card-body">
+					<h2 class="card-title">Tabs</h2>
+					<div role="tablist" class="tabs tabs-bordered">
+						<input type="radio" name="tabs" role="tab" class="tab" aria-label="One" checked />
+						<div role="tabpanel" class="tab-content p-4">Tab One content</div>
+						<input type="radio" name="tabs" role="tab" class="tab" aria-label="Two" />
+						<div role="tabpanel" class="tab-content p-4">Tab Two content</div>
+						<input type="radio" name="tabs" role="tab" class="tab" aria-label="Three" />
+						<div role="tabpanel" class="tab-content p-4">Tab Three content</div>
+					</div>
+				</div>
+			</div>
+
+			<!-- Form -->
+			<div class="card bg-base-300 shadow-xl">
+				<div class="card-body">
+					<h2 class="card-title">Form</h2>
+					<form class="space-y-4">
+						<label class="form-control w-full">
+							<div class="label">
+								<span class="label-text">Email</span>
+							</div>
+							<input type="email" placeholder="you@example.com" class="input input-bordered w-full" />
+						</label>
+						<label class="form-control w-full">
+							<div class="label">
+								<span class="label-text">Pick a fruit</span>
+							</div>
+							<select class="select select-bordered">
+								<option>Apple</option>
+								<option>Banana</option>
+								<option>Cherry</option>
+							</select>
+						</label>
+						<div class="flex items-center gap-3">
+							<input type="checkbox" class="checkbox" />
+							<span>Subscribe</span>
+						</div>
+						<div class="card-actions justify-end">
+							<button type="submit" class="btn btn-primary">Submit</button>
+							<button type="reset" class="btn">Reset</button>
+						</div>
+					</form>
+				</div>
+			</div>
+
+			<!-- Alerts -->
+			<div class="card bg-base-300 shadow-xl">
+				<div class="card-body">
+					<h2 class="card-title">Alerts</h2>
+					<div class="space-y-3">
+						<div role="alert" class="alert alert-info">
+							<span>Info alert</span>
+						</div>
+						<div role="alert" class="alert alert-success">
+							<span>Success alert</span>
+						</div>
+						<div role="alert" class="alert alert-warning">
+							<span>Warning alert</span>
+						</div>
+						<div role="alert" class="alert alert-error">
+							<span>Error alert</span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</body>
+</html>


### PR DESCRIPTION
Add a DaisyUI test app and enable static `Apps.json` loading for the app launcher.

To fulfill the request of creating the 'daisyui components test' app defined in `Apps/Apps.json`, `frontend/index.ts` was updated to ensure the app launcher can discover and display apps from `Apps.json` when the `/apps` API is unavailable, supporting static hosting.

---
<a href="https://cursor.com/background-agent?bcId=bc-3852cb14-d7e1-40b9-b379-55052718256f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3852cb14-d7e1-40b9-b379-55052718256f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

